### PR TITLE
feature(extend): use file as base template of properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const util = require('util');
 const meow = require('meow');
+const properties = require('properties');
 const writeFile = util.promisify(fs.writeFile);
 
 const root = process.cwd();
@@ -12,17 +13,17 @@ const package = require(root + '/package.json');
 const cli = meow(`
     Usage
       $ sonar-prop
- 
+
     Description
-        This tool will create the sonar-project.properties file for a SonarQube scan. 
+        This tool will create the 'sonar-project.properties' file for a SonarQube scan. It can extend if exist file '.sonar-project.properties'
 
     Options
          --id  App unique ID.  Can be set throught the SONAR_ID environment variable
          --name, n App name. By Default gets the package.json name. Can be set through the SONAR_NAME environment variable
          --url, u Required SonarQube server url. Can be set throught the SONAR_URL environment variable
          --version, v App version number. By default gets the package.json version number. Can be set through the SONAR_VERSION environment variable
-         --token, t Required SonarQube token . Can be set through the SONAR_TOKEN environment variable. 
- 
+         --token, t Required SonarQube token . Can be set through the SONAR_TOKEN environment variable.
+
     Examples
       $ sonar-prop --id=MyUID --name=AppName --url=SonarQubeURL --version=1.0.1 --token=SonarToken
       ð unicorns ð
@@ -56,47 +57,29 @@ const cli = meow(`
     autoHelp: true
 });
 
+properties.parse ('.sonar-project.properties', { path: true }, (error, props = {}) => {
+    // variables for the sonarqube configuration
+    const id = cli.flags.id || process.env.SONAR_ID || props['sonar.projecKey'] || package.name;
+    const paths = cli.flags.paths || process.env.SONAR_PATHS || props['sonar.sources'] || 'src/js/app,src/js/modules';
+    const name = cli.flags.name || process.env.SONAR_NAME || props['sonar.projectName'] || package.name;
+    const token = cli.flags.token || process.env.SONAR_TOKEN || props['sonar.login'] || 'TOKEN_HERE';
+    const url = cli.flags.url || process.env.SONAR_URL || props['sonar.host.url'];
+    const version = cli.flags.version || process.env.SONAR_VERSION || props['sonar.projecVersion'] || package.version;
 
+    if(!id || !paths || !name || !token || !url || !version){
+        console.log(`You should use the arguments, environment variables or base file '.sonar-project,properties' to fullfill the required information`);
+        process.exit(1);
+    }
 
-// variables for the sonarqube configuration
-const id = cli.flags.id || process.env.SONAR_ID || package.name;
-const paths = cli.flags.paths || process.env.SONAR_PATHS || 'src/js/app,src/js/modules';
-const name = cli.flags.name || process.env.SONAR_NAME || package.name;
-const token = cli.flags.token || process.env.SONAR_TOKEN || 'TOKEN_HERE';
-const url = cli.flags.url || process.env.SONAR_URL;
-const version = cli.flags.version || process.env.SONAR_VERSION || package.version;
+    props['sonar.projectKey'] = name;
+    props['sonar.sources'] = paths;
+    props['sonar.projectName'] = name;
+    props['sonar.login'] = token;
+    props['sonar.host.url'] = url;
+    props['sonar.projectVersion'] = version;
 
-if(!id || !paths || !name || !token || !url || !version){
-    console.log(`You should use the arguments or environment variables to fullfill the required information`);
-    process.exit(1);
-}
-
-// config file template
-let sonarProjectProperties = `
-# Accedo SonarQube server
-sonar.host.url=${url}
- 
-# App key (must be unique!) in a given SonarQube instance
-sonar.projectKey=${id}
- 
-# App name (preferably unique)
-sonar.projectName=${name}
- 
-# App version 
-sonar.projectVersion=${version}
- 
-# source files to include (change this according to your project!)
-sonar.sources=${paths}
- 
-# encoding of the source code. Default is default system encoding
-sonar.sourceEncoding=UTF-8 
- 
-# possible login credentials needed for the SonarQube server
-sonar.login=${token}
-`;
-
-// write file and exit with a 0 code (default, success) or a 1 (error)
-writeFile('sonar-project.properties', sonarProjectProperties)
+    // write file and exit with a 0 code (default, success) or a 1 (error)
+    writeFile('sonar-project.properties', properties.stringify(props))
     .then(() => {
         console.log('sonar-project.properties file created!');
     })
@@ -104,3 +87,4 @@ writeFile('sonar-project.properties', sonarProjectProperties)
         console.log(err);
         process.exit(1);
     });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -235,6 +235,11 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
+    "properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/properties/-/properties-1.2.1.tgz",
+      "integrity": "sha1-Dul6f8AgsaKlW4ZZ7aSqjYaQlL0="
+    },
     "quick-lru": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/ignaciolg/sonar-prop#readme",
   "dependencies": {
-    "meow": "^5.0.0"
+    "meow": "^5.0.0",
+    "properties": "^1.2.1"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# sonar-prop 
+# sonar-prop
 
 >  helper to create sonar-project.properties files
 
@@ -6,18 +6,19 @@
 - Arguments
 - Environment variables
 - Read name and version from package.json
+- Extend properties file '.sonar-project.properties'
 
 ## Usage
 
 ```
 $ npx --help
-$ npx --id=MyID --paths="src/js/app,src/js/modules" --name=MyName --url=https://sonar.url --token=SECRETTOKEN --version=1.2.3  
+$ npx --id=MyID --paths="src/js/app,src/js/modules" --name=MyName --url=https://sonar.url --token=SECRETTOKEN --version=1.2.3
 ```
 
 ## Arguments
-- id - UID The SONAR_ID environment variable can be used. The SONAR_ID environment variable can be used. 
-- paths - Quoted paths for the SonarQube analysis comma separated. The SONAR_PATHS environment variable canb e used. 
-- name - Name of the application. Defaults to package.json name. The SONAR_NAME environment variable can be used. 
-- url - URL of the SonarQube server. The SONAR_URL environment variable can be used. 
-- token - Secret token for SonarQube authentication. The SONAR_TOKEN environment variable can be used. 
-- version - Version of the application. Defaults to package.json version. The SONAR_VERSION environment variable can be used. 
+- id - UID The SONAR_ID environment variable can be used. The SONAR_ID environment variable can be used.
+- paths - Quoted paths for the SonarQube analysis comma separated. The SONAR_PATHS environment variable canb e used.
+- name - Name of the application. Defaults to package.json name. The SONAR_NAME environment variable can be used.
+- url - URL of the SonarQube server. The SONAR_URL environment variable can be used.
+- token - Secret token for SonarQube authentication. The SONAR_TOKEN environment variable can be used.
+- version - Version of the application. Defaults to package.json version. The SONAR_VERSION environment variable can be used.


### PR DESCRIPTION
Add the possibility to use one . ba se properties file which can be modified under version control.

File should be .sonar-project.properties